### PR TITLE
Easy Button (easy-button-button dimension edits)

### DIFF
--- a/src/easy-button.css
+++ b/src/easy-button.css
@@ -43,8 +43,6 @@
 
 .easy-button-button .button-state{
   display: block;
-  width: 100%;
-  height: 100%;
   position: relative;
 }
 


### PR DESCRIPTION
My goal was to get the easy button to center a button icon within the boundaries of the button.  That proved difficult and I felt it should be default behavior.  I am very willing to discuss this at a later date or time, as I'm probably doing something wrong.  

A more detailed explanation:

I Removed the width and height from the easy button button.  At 100% a piece it was causing icons to float against the upper edge of the button. By removing the width and height from the easy-button-button class I was able to produce the desired behavior.

I would love to hear from you at your convenience.  Thanks for considering this request. 

