### PR TITLE
fixed mouse pointer using leaflet-interactive class

### DIFF
--- a/src/easy-button.js
+++ b/src/easy-button.js
@@ -173,7 +173,7 @@ L.Control.EasyButton = L.Control.extend({
     }
 
     if (this.options.leafletClasses){
-      L.DomUtil.addClass(this.button, 'easy-button-button leaflet-bar-part');
+      L.DomUtil.addClass(this.button, 'easy-button-button leaflet-bar-part leaflet-interactive');
     }
 
     // don't let double clicks get to the map


### PR DESCRIPTION
With leaflet 1.0-rcX the pointer does not match a clickable object. This fixes the problem by using a leaflet css class