### PR TITLE
Stop propagation of mousedown for Leaflet 0.7.[5-7] too

### DIFF
--- a/src/easy-button.js
+++ b/src/easy-button.js
@@ -177,7 +177,8 @@ L.Control.EasyButton = L.Control.extend({
     }
 
     // don't let double clicks and mousedown get to the map
-    L.DomEvent.addListener(this.button, 'dblclick mousedown', L.DomEvent.stop);
+    L.DomEvent.addListener(this.button, 'dblclick', L.DomEvent.stop);
+    L.DomEvent.addListener(this.button, 'mousedown', L.DomEvent.stop);
 
     // take care of normal clicks
     L.DomEvent.addListener(this.button,'click', function(e){


### PR DESCRIPTION
In addition to PR https://github.com/CliffCloud/Leaflet.EasyButton/pull/45 .

In stable branch L.DomEvent.addListener accept only one event:
https://github.com/Leaflet/Leaflet/blob/v0.7.7/src/dom/DomEvent.js