### PR TITLE
Set button type to button element

### DIFF
--- a/src/easy-button.js
+++ b/src/easy-button.js
@@ -168,6 +168,8 @@ L.Control.EasyButton = L.Control.extend({
 
     this.button = L.DomUtil.create('button', '');
 
+    this.button.type = 'button';
+    
     if (this.options.id ){
       this.button.id = this.options.id;
     }


### PR DESCRIPTION
When add a map in a form,  Easy button prevent the form to submit  when user press enter in any  form input.
