### PR TITLE
Update Leaflet dependency version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "src/easy-button.css"
   ],
   "dependencies": {
-    "leaflet": "~0.7.3"
+    "leaflet": "~1.0.1"
   },
   "keywords": [
     "Leaflet",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "homepage": "https://github.com/CliffCloud/Leaflet.EasyButton",
   "dependencies": {
-    "leaflet": "^0.7.5"
+    "leaflet": "^1.0.1"
   }
 }


### PR DESCRIPTION
I've been using EasyButton with Leaflet@1.0.1 and have found no issues. It appears the Leaflet API used by EasyButton hasn't changed much since ~0.7. But I think this still constitutes a 2.0 major release for EasyButton since people might be still using Leaflet@0.7 in production. 
