### PR TITLE
Compatibility with leaflet 1.2.0

### DIFF
--- a/src/easy-button.d.ts
+++ b/src/easy-button.d.ts
@@ -1,4 +1,7 @@
-declare namespace L {
+import * as L from 'leaflet'
+
+declare module 'leaflet' {
+
     /**
      * Creates a bar that holds a group of EasyButtons
      * @param buttons array of EasyButtons that will be grouped together in the EasyBar
@@ -50,7 +53,7 @@ declare namespace L {
     namespace Control {
         class EasyButton extends L.Control {
             constructor(options?: EasyButtonOptions)
-            state(stateName: string)
+            state(stateName: string): EasyButton
         }
         class EasyBar extends L.Control {
             constructor(options?: EasyBarOptions)


### PR DESCRIPTION
Addresses #71  

To augment leaflet 1.2.0's javascript modules, use Typescript _Module Augmentation_. https://www.typescriptlang.org/docs/handbook/declaration-merging.html 