### PR TITLE
mouseup event needs propagation stopped as well

### DIFF
--- a/src/easy-button.js
+++ b/src/easy-button.js
@@ -184,6 +184,7 @@ L.Control.EasyButton = L.Control.extend({
     // don't let double clicks and mousedown get to the map
     L.DomEvent.addListener(this.button, 'dblclick', L.DomEvent.stop);
     L.DomEvent.addListener(this.button, 'mousedown', L.DomEvent.stop);
+    L.DomEvent.addListener(this.button, 'mouseup', L.DomEvent.stop);
 
     // take care of normal clicks
     L.DomEvent.addListener(this.button,'click', function(e){


### PR DESCRIPTION
Was having an issue with this when trying to add a draggable button to my map. This change was all that was needed. 