### PR TITLE
Removing Warning... error Missing '()' invoking a constructor

### DIFF
--- a/src/easy-button.js
+++ b/src/easy-button.js
@@ -87,7 +87,7 @@ L.easyBar = function(){
   for(var i = 0; i < arguments.length; i++){
     args.push( arguments[i] );
   }
-  return new (Function.prototype.bind.apply(L.Control.EasyBar, args));
+  return new (Function.prototype.bind.apply(L.Control.EasyBar, args))();
 };
 
 // L.EasyButton is the actual buttons
@@ -312,7 +312,7 @@ L.Control.EasyButton = L.Control.extend({
 
 L.easyButton = function(/* args will pass automatically */){
   var args = Array.prototype.concat.apply([L.Control.EasyButton],arguments);
-  return new (Function.prototype.bind.apply(L.Control.EasyButton, args));
+  return new (Function.prototype.bind.apply(L.Control.EasyButton, args))();
 };
 
 /*************************


### PR DESCRIPTION
https://eslint.org/docs/2.0.0/rules/new-parens
_"This rule is aimed at highlighting a lack of convention and increasing code clarity by requiring the use of parentheses when invoking a constructor via the new keyword. As such, it will warn when these parentheses are omitted."_