### PR TITLE
setActive for buttons

### DIFF
--- a/src/easy-button.css
+++ b/src/easy-button.css
@@ -41,6 +41,14 @@
   opacity: .4;
 }
 
+.leaflet-bar button.active {
+  background-position: 50% 50%;
+  background-repeat: no-repeat;
+  overflow: hidden;
+  display: block;
+  background-color: lightgrey;
+}
+
 .easy-button-button .button-state{
   display: block;
   width: 100%;

--- a/src/easy-button.js
+++ b/src/easy-button.js
@@ -297,6 +297,18 @@ L.Control.EasyButton = L.Control.extend({
     return this;
   },
 
+  setActive: function() {
+    L.DomUtil.addClass(this.button, 'active');
+    this.active = true;
+    return this;
+  },
+
+  setInactive: function() {
+    L.DomUtil.removeClass(this.button, 'active');
+    this.active = false;
+    return this;
+  },
+
   onAdd: function(map){
     var bar = L.easyBar([this], {
       position: this.options.position,


### PR DESCRIPTION
Hey, thank you for creating this plugin. Consider the following case:
You have an EasyBar with different buttons for, e.g. selecting the color you want your paths to have.
Now, you want to display which color is currently selected. The PR implements two functions, setActive() and setInactive() alongside a corresponding CSS class. The following code illustrates the use of the new functions. When you select a button, its color changes to lightgrey. When you select another button, the first button changes back to white and the now selected button gets lightgrey.

Others might find this useful too. Let me know what you think!
```
var button1, button2, button3, button4;
var buttons = [
    button1 = L.easyButton('<img alt="some button" src="img/some-button.png" height="15px" width="15px" />', function () {
        // do stuff
        changeActive();
        button1.setActive();
    }),
    button2 = L.easyButton('<img alt="some button" src="img/some-button.png" height="15px" width="15px" />', function () {
        // do stuff
        changeActive();
        button2.setActive();
    }),
    button3 = L.easyButton('<img alt="some button" src="img/some-button.png" height="15px" width="15px" />', function () {
        // do stuff
        changeActive();
        button3.setActive();
    }),
    button4 = L.easyButton('<img alt="some button" src="img/some-button.png" height="15px" width="15px" />', function () {
        // do stuff
        changeActive();
        button4.setActive();
    }),
];
L.easyBar(buttons).addTo(map);
function changeActive() {
    buttons.forEach(i => {
        if (i.active == true) { i.setInactive() };
    });
};
```