### PR TITLE
Add select function to button

### DIFF
--- a/src/easy-button.js
+++ b/src/easy-button.js
@@ -53,6 +53,15 @@ L.Control.EasyBar = L.Control.extend({
     return this;
   },
 
+  select: function(){
+    L.DomUtil.addClass(this.button, 'selected');
+    return this;
+  },
+
+  unselect: function(){
+    L.DomUtil.removeClass(this.button, 'selected');
+    return this;
+  },
 
   onAdd: function () {
     return this.container;


### PR DESCRIPTION
This simple addition added select and unselect method to buttons which add or remove a '.selected' class to the button. This is useful when controls activate a new mode (eg drawing) which captures mouse actions until deselected. A user can add a style like:
.leaflet-bar button.selected{
    background-color: #666666 !important;    
}

to style the button. I considered putting a default into the easybutton.css but though better of it.