### PR TITLE
Update easy-button.d.ts to match code change in f903381

### DIFF
--- a/src/easy-button.d.ts
+++ b/src/easy-button.d.ts
@@ -75,6 +75,7 @@ declare module 'leaflet' {
     class EasyButton extends L.Control {
       constructor(options?: EasyButtonOptions)
 
+      state(): string
       state(stateName: string): EasyButton
       enable(): void
       disable(): void


### PR DESCRIPTION
button.state() can now be used without arguments to retrieve the state name.  (Very belatedly!) update the TypeScript file to reflect this possible usage.